### PR TITLE
Hostile 2.0.0

### DIFF
--- a/src/homi_pipeline/conda_envs/hostile.yaml
+++ b/src/homi_pipeline/conda_envs/hostile.yaml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - hostile
+  - hostile>=2.0.0

--- a/src/homi_pipeline/snakefile
+++ b/src/homi_pipeline/snakefile
@@ -410,7 +410,7 @@ rule host_filter:
     """
     hostile clean \
     --fastq1 {input.FWD} --fastq2 {input.REV} \
-    --out-dir {params.trim_trunc_path}.nonhost \
+    -o {params.trim_trunc_path}.nonhost \
     --threads {threads} \
     --index {params.hostile_db_path} \
     --debug \


### PR DESCRIPTION
Addresses #95 .

@jboconnor13 can you please make sure this resolves your issue? It seems to be working for me.

You should be able to use to update your homi version - if you run into issues with this, let me know
```
pip install --upgrade git+https://github.com/sterrettJD/HoMi.git@hostile_2
```